### PR TITLE
Fix order of colors in doolittle 797.

### DIFF
--- a/797/doolittle/index.html
+++ b/797/doolittle/index.html
@@ -123,7 +123,7 @@
           lineHeight   = LINE_THICKNESS + LINE_PADDING,
           numLines     = viewHeight/lineHeight,
           line, lastLine
-          lineId = 0, i = -1;
+          lineId = -1, i = -1;
 
         console.log("Drawing lines:", numLines);
 


### PR DESCRIPTION
It seems to me like the order of the colors in doolittle's interpretation of 797 is wrong:

```
The first drafter has a black marker and makes an irregular horizontal line near the top of the wall. Then the second drafter tries to copy it (without touching it) using a red marker. The third drafter does the same, using a yellow marker. The fourth drafter does the same using a blue marker. Then the second drafter followed by the third and fourth copies the last line drawn until the bottom of the wall is reached.
```

So the order should be

1. black
2. red
3. yellow
4. blue
5. red
6. ...

Currently the order starts with `yellow` after `black` which seems to not match the description.